### PR TITLE
Doc formatting

### DIFF
--- a/ai_search_utilities.py
+++ b/ai_search_utilities.py
@@ -207,7 +207,7 @@ def create_vector_index(stem_name, user_fields, omit_timestamp=False):
     client = SearchIndexClient(endpoint=search_endpoint, credential=credential)
 
     # Define the fields for the index
-    fields = [SimpleField(name="id", type=SearchFieldDataType.String, key=True)]
+    fields = [SimpleField(name="id", type=SearchFieldDataType.String, key=True), SimpleField(name="sourcefileref", type=SearchFieldDataType.String,searchable=False, filterable=True)]
     
     # Add user-defined fields to the index
     for field, field_type in user_fields.items():

--- a/function_app.py
+++ b/function_app.py
@@ -1463,6 +1463,9 @@ def chunk_extracts(activitypayload: str):
             # Load the extracts file as a JSON string
             extract_data = json.loads((extract_blob_client.download_blob().readall()).decode('utf-8'))
 
+            # Create a shortened file reference for the source file attached to the extract
+            extract_data['sourcefileref'] = hashlib.md5(extract_data['sourcefile'].encode()) + extract_data['sourcefile'].split('.')[-1]
+
             # Load the image analysis file as a JSON string
             if image_analysis_client.exists():
                 image_analysis_data = json.loads(image_analysis_client.download_blob().readall())
@@ -1493,6 +1496,9 @@ def chunk_extracts(activitypayload: str):
 
             # Load the extracts file as a JSON string
             extract_data = json.loads((extract_blob_client.download_blob().readall()).decode('utf-8'))
+
+            # Create a shortened file reference for the source file attached to the extract
+            extract_data['sourcefileref'] = hashlib.md5(extract_data['sourcefile'].encode()) + extract_data['sourcefile'].split('.')[-1]
 
             # Load the image analysis file as a JSON string
             if image_analysis_client.exists():

--- a/function_app.py
+++ b/function_app.py
@@ -1464,7 +1464,7 @@ def chunk_extracts(activitypayload: str):
             extract_data = json.loads((extract_blob_client.download_blob().readall()).decode('utf-8'))
 
             # Create a shortened file reference for the source file attached to the extract
-            extract_data['sourcefileref'] = hashlib.md5(extract_data['sourcefile'].encode()) + extract_data['sourcefile'].split('.')[-1]
+            extract_data['sourcefileref'] = hashlib.md5(extract_data['sourcefile'].encode()).hexdigest() + '.' + extract_data['sourcefile'].split('.')[-1]
 
             # Load the image analysis file as a JSON string
             if image_analysis_client.exists():
@@ -1498,7 +1498,7 @@ def chunk_extracts(activitypayload: str):
             extract_data = json.loads((extract_blob_client.download_blob().readall()).decode('utf-8'))
 
             # Create a shortened file reference for the source file attached to the extract
-            extract_data['sourcefileref'] = hashlib.md5(extract_data['sourcefile'].encode()) + extract_data['sourcefile'].split('.')[-1]
+            extract_data['sourcefileref'] = hashlib.md5(extract_data['sourcefile'].encode()).hexdigest() + '.' + extract_data['sourcefile'].split('.')[-1]
 
             # Load the image analysis file as a JSON string
             if image_analysis_client.exists():
@@ -1599,6 +1599,7 @@ def chunk_audio_video_transcripts(activitypayload: str):
                 extract_data['content'] = chunk
                 extract_data['sourcefile'] = transcript_data['sourcefile']
                 extract_data['chunkcount'] = idx
+                extract_data['sourcefileref'] = hashlib.md5(extract_data['sourcefile'].encode()).hexdigest() + '.' + extract_data['sourcefile'].split('.')[-1]
 
                 filename = file.split('.')[0] + f'_chunk_{idx}.json'
 
@@ -1630,6 +1631,7 @@ def chunk_audio_video_transcripts(activitypayload: str):
                 extract_data['sourcefile'] = transcript_data['sourcefile']
                 extract_data['chunkcount'] = idx+1
                 extract_data['category'] = transcript_data['category']
+                extract_data['sourcefileref'] = hashlib.md5(extract_data['sourcefile'].encode()).hexdigest() + '.' + extract_data['sourcefile'].split('.')[-1]
 
                 filename = file.split('.')[0] + f'_chunk_{idx+1}.json'
 


### PR DESCRIPTION
Branch has logic to include a shortened reference filename (derived from md5 hash of source file string) in addition to the name of the source document in all extracts and indexed records